### PR TITLE
Update Cloud for Paper 1.17 support

### DIFF
--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -88,10 +88,6 @@
             <id>egg82-nexus</id>
             <url>https://nexus.egg82.me/repository/maven-releases/</url>
         </repository>
-        <repository> <!-- for development builds -->
-            <id>sonatype-oss-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
         <repository>
             <id>sponge</id>
             <url>https://repo.spongepowered.org/repository/maven-public/</url>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -88,6 +88,10 @@
             <id>egg82-nexus</id>
             <url>https://nexus.egg82.me/repository/maven-releases/</url>
         </repository>
+        <repository> <!-- for development builds -->
+            <id>sonatype-oss-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
         <repository>
             <id>sponge</id>
             <url>https://repo.spongepowered.org/repository/maven-public/</url>

--- a/Paper/pom.xml
+++ b/Paper/pom.xml
@@ -193,10 +193,6 @@
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
-        <repository> <!-- for development builds -->
-            <id>sonatype-oss-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
         <!--<repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>

--- a/Paper/pom.xml
+++ b/Paper/pom.xml
@@ -123,10 +123,6 @@
                             <pattern>redis.clients.jedis</pattern>
                             <shadedPattern>me.egg82.antivpn.external.redis.clients.jedis</shadedPattern>
                         </relocation>
-                        <relocation>
-                            <pattern>it.unimi.dsi</pattern>
-                            <shadedPattern>me.egg82.antivpn.external.it.unimi.dsi</shadedPattern>
-                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -197,6 +193,10 @@
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
+        <repository> <!-- for development builds -->
+            <id>sonatype-oss-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
         <!--<repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -241,7 +241,6 @@
             <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <jetbrains.version>20.1.0</jetbrains.version>
         <junit.version>5.8.0-M1</junit.version>
 
-        <cloud.version>1.4.0</cloud.version>
-        <commodore.version>1.9</commodore.version>
+        <cloud.version>1.5.0</cloud.version>
+        <commodore.version>1.10</commodore.version>
         <adventure.version>4.7.0</adventure.version> <!-- keep updated with Paper: https://github.com/PaperMC/Paper/blob/master/Spigot-API-Patches/0005-Adventure.patch -->
         <adventure.bukkit.version>4.0.0-SNAPSHOT</adventure.bukkit.version>
         <minimessage.version>4.1.0-SNAPSHOT</minimessage.version>


### PR DESCRIPTION
Removes the relocation for fastutil because it isn't needed
Updates Cloud & Commodore for 1.17 support

Tested on Paper-79 (1.17)